### PR TITLE
possible bug fix in locus sort in gl.filter.secondaries and in locus names in gl.sexlinkage

### DIFF
--- a/R/gl.filter.secondaries.r
+++ b/R/gl.filter.secondaries.r
@@ -39,12 +39,15 @@ gl.filter.secondaries <- function(x, method="random", v=2) {
 # Sort the genlight object on AlleleID (asc), RepAvg (desc), AvgPIC (desc) 
   if (method == "best") {
     if (v > 1){cat("  Selecting one SNP per sequence tag based on best RepAvg and AvgPIC\n")}
-    x <- x[,order(x@other$loc.metrics$AlleleID,-x@other$loc.metrics$RepAvg,-x@other$loc.metrics$AvgPIC)]
+    loc.order <- order(x@other$loc.metrics$AlleleID,-x@other$loc.metrics$RepAvg,-x@other$loc.metrics$AvgPIC)
+    x <- x[, loc.order]
+    x@other$loc.metrics <- x@other$loc.metrics[loc.order, ]
   } else {
     if (v > 1){cat("  Selecting one SNP per sequence tag at random\n")}
     n <- length(x@other$loc.metrics$AlleleID)
     index <- sample(1:(n+10000),size=n,replace=FALSE)
     x <- x[,order(index)]
+    x@other$loc.metrics <- x@other$loc.metrics[order(index), ]
   }
 # Extract the clone ID number
   a <- strsplit(as.character(x@other$loc.metrics$AlleleID),"\\|")

--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -63,11 +63,9 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
 # Combine the two files
   Trimmed_Sequence <- x@other$loc.metrics$TrimmedSequence
   df <- cbind(dff,dfm,Trimmed_Sequence)
-  a <- strsplit(row.names(df), split="\\|")
+  a <- strsplit(row.names(df), split="-")
   a <- do.call(rbind,a)
-  a <- strsplit(a[,2],"-")
-  a <- do.call(rbind,a)
-  a <- as.numeric(a[,1])
+  a <- as.numeric(a[,2])
   
   df$Trimmed_Sequence <- as.character(df$Trimmed_Sequence)
   b <- substr(df$Trimmed_Sequence,1,a)


### PR DESCRIPTION
I've been using these two functions and noticed some weird things happening with the gl.filter.secondaries function. I think it's sorting the columns in the main genlight object but not sorting the locus names in the loc.metrics dataframe. This meant that it was correctly identifying duplicates but then removing the wrong SNPs from the main genlight object.

This is a simple test function that identifies the problem:
```
check_dartR_locnames <- function(x) {
  
  loc.names <- sapply(strsplit(adegenet::locNames(x), split = '-'),
                      function(x) x[1])
  loc.metric.names <- sapply(strsplit(as.character(x@other$loc.metrics$AlleleID),
                                      split = '\\|'),
                             function(x) x[1])
  
  all.equal(loc.names, loc.metric.names)
    
}
```

This function should return TRUE.

The sexlinkage function also errored when trying to subset the trimmed sequence -- the strsplit() function was looking for "|" but these are removed from the locNames output. I've added a minor tweak to address this but this might not be correct.

