### PR TITLE
Zero alleles

### DIFF
--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -63,9 +63,7 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
 # Combine the two files
   Trimmed_Sequence <- x@other$loc.metrics$TrimmedSequence
   df <- cbind(dff,dfm,Trimmed_Sequence)
-  a <- strsplit(row.names(df), split="\\|")
-  a <- do.call(rbind,a)
-  a <- strsplit(a[,2],"-")
+  a <- strsplit(row.names(df), split="-")
   a <- do.call(rbind,a)
   a <- as.numeric(a[,1])
   

--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -82,8 +82,10 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
   summ <- df$M0+df$M1+df$M2
   df_zero_sum <- df[(sumf == 0) | (summ == 0), ]
   df <- df[(sumf > 0) & (summ > 0), ]
-  zw <- df[df$F1/(sumf[sumf > 0])>=(1-t.hom) & df$M1/(summ[summ > 0])<=(0+t.het),]
-  xy <- df[df$F1/(sumf[sumf > 0])<=(0+t.het) & df$M1/(summ[summ > 0])>=(1-t.hom),]
+  zw <- df[df$F1/(sumf[(sumf > 0) & (summ > 0)]) >= (1 - t.hom) &
+             df$M1/(summ[(sumf > 0) & (summ > 0)]) <= (0 + t.het), ]
+  xy <- df[df$F1/(sumf[(sumf > 0) & (summ > 0)]) <= (0 + t.het) &
+             df$M1/(summ[(sumf > 0) & (summ > 0)]) >= (1 - t.hom), ]
   
   if (nrow(zw) == 0){
     cat("No sex linked markers consistent with female heterogamety (ZZ/ZW)\n")
@@ -108,7 +110,7 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
     cat("Note: The most reliable putative markers will have AvgCount for Ref or Snp 10 or more, one ca half the other\n")
   }
   if (nrow(df_zero_sum) != 0){
-    cat("\nSound loci with zero alleles for one sex\n")
+    cat("\nFound loci with zero alleles for one sex\n")
     print(df_zero_sum)
   } 
   

--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -65,7 +65,7 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
   df <- cbind(dff,dfm,Trimmed_Sequence)
   a <- strsplit(row.names(df), split="-")
   a <- do.call(rbind,a)
-  a <- as.numeric(a[,1])
+  a <- as.numeric(a[,2])
   
   df$Trimmed_Sequence <- as.character(df$Trimmed_Sequence)
   b <- substr(df$Trimmed_Sequence,1,a)

--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -80,35 +80,40 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
 # Check for hets in all males, homs in all females (XY); ditto for ZW
   sumf <- df$F0+df$F1+df$F2
   summ <- df$M0+df$M1+df$M2
+  df_zero_sum <- df[(sumf == 0) | (summ == 0), ]
   df <- df[(sumf > 0) & (summ > 0), ]
-  zw <- df[df$F1/(sumf)>=(1-t.hom) & df$M1/(summ)<=(0+t.het),]
-  xy <- df[df$F1/(sumf)<=(0+t.het) & df$M1/(summ)>=(1-t.hom),]
-
-if (nrow(zw) == 0){
-  cat("No sex linked markers consistent with female heterogamety (ZZ/ZW)\n")
-} else {
-  cat("\nSex linked loci consistent with female heterogamety (ZZ/ZW)\n")
-  cat(paste("  Threshold proportion for homozygotes in the heterozygotic sex (ZW)",t.hom,";\n")) 
-  cat(paste("  for heterozygotes in the homozygotic sex (ZZ)",t.het,"\n"))
-  cat("  0 = homozygous reference; 1 = heterozygous; 2 = homozygous alternate\n")
-  print(zw)
-  cat("Note: Snp location in Trimmed Sequence indexed from 0 not 1, SNP position in lower case\n")
-  cat("Note: The most reliable putative markers will have AvgCount for Ref or Snp 10 or more, one ca half the other\n")
-}
-if (nrow(xy) == 0){
-  cat("No sex linked markers consistent with male heterogamety (XX/XY)\n")
-} else {
-  cat("\nSex linked loci consistent with male heterogamety (XX/XY)\n")
-  cat(paste("  Threshold proportion for homozygotes in the heterozygotic sex (XY)",t.hom,";\n")) 
-  cat(paste("  for heterozygotes in the homozygotic sex (XX)",t.het,"\n"))
-  cat("  0 = homozygous reference; 1 = heterozygous; 2 = homozygous alternate\n")
-  print(xy)
-  cat("Note: Snp location in Trimmed Sequence indexed from 0 not 1, SNP position in lower case\n")
-  cat("Note: The most reliable putative markers will have AvgCount for Ref or Snp 10 or more, one ca half the other\n")
+  zw <- df[df$F1/(sumf[sumf > 0])>=(1-t.hom) & df$M1/(summ[summ > 0])<=(0+t.het),]
+  xy <- df[df$F1/(sumf[sumf > 0])<=(0+t.het) & df$M1/(summ[summ > 0])>=(1-t.hom),]
+  
+  if (nrow(zw) == 0){
+    cat("No sex linked markers consistent with female heterogamety (ZZ/ZW)\n")
+  } else {
+    cat("\nSex linked loci consistent with female heterogamety (ZZ/ZW)\n")
+    cat(paste("  Threshold proportion for homozygotes in the heterozygotic sex (ZW)",t.hom,";\n")) 
+    cat(paste("  for heterozygotes in the homozygotic sex (ZZ)",t.het,"\n"))
+    cat("  0 = homozygous reference; 1 = heterozygous; 2 = homozygous alternate\n")
+    print(zw)
+    cat("Note: Snp location in Trimmed Sequence indexed from 0 not 1, SNP position in lower case\n")
+    cat("Note: The most reliable putative markers will have AvgCount for Ref or Snp 10 or more, one ca half the other\n")
   }
-
-l <- list(zw,xy)
-
-return(l)
-
+  if (nrow(xy) == 0){
+    cat("No sex linked markers consistent with male heterogamety (XX/XY)\n")
+  } else {
+    cat("\nSex linked loci consistent with male heterogamety (XX/XY)\n")
+    cat(paste("  Threshold proportion for homozygotes in the heterozygotic sex (XY)",t.hom,";\n")) 
+    cat(paste("  for heterozygotes in the homozygotic sex (XX)",t.het,"\n"))
+    cat("  0 = homozygous reference; 1 = heterozygous; 2 = homozygous alternate\n")
+    print(xy)
+    cat("Note: Snp location in Trimmed Sequence indexed from 0 not 1, SNP position in lower case\n")
+    cat("Note: The most reliable putative markers will have AvgCount for Ref or Snp 10 or more, one ca half the other\n")
+  }
+  if (nrow(df_zero_sum) != 0){
+    cat("\nSound loci with zero alleles for one sex\n")
+    print(df_zero_sum)
+  } 
+  
+  l <- list(zw,xy, df_zero_sum)
+  
+  l
+  
 }

--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -82,6 +82,7 @@ gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
 # Check for hets in all males, homs in all females (XY); ditto for ZW
   sumf <- df$F0+df$F1+df$F2
   summ <- df$M0+df$M1+df$M2
+  df <- df[(sumf > 0) & (summ > 0), ]
   zw <- df[df$F1/(sumf)>=(1-t.hom) & df$M1/(summ)<=(0+t.het),]
   xy <- df[df$F1/(sumf)<=(0+t.het) & df$M1/(summ)>=(1-t.hom),]
 

--- a/R/gl.sexlinkage.r
+++ b/R/gl.sexlinkage.r
@@ -15,14 +15,20 @@
 #' @param t.hom -- tolerance, that is tf=0.05 means that 5% of the homogametic sex can be heterozygous and still
 #' be regarded as consistent with a sex specific marker [default 0]
 #' @param v -- verbosity: 0, silent or fatal errors; 1, begin and end; 2, progress log ; 3, progress and results summary; 5, full report [default 2]
+#' @param na.rm -- logical: should NAs in sex assignments be ignored?
 #' @return The list of sex specific loci
 #' @export
 #' @author Arthur Georges (glbugs@aerg.canberra.edu.au)
 #' @examples
 #' result <- gl.sexlinkage(testset.gl)
 
-gl.sexlinkage <- function(x, t.het=0, t.hom=0, v=2) {
+gl.sexlinkage <- function(x, t.het = 0, t.hom = 0, v = 2, na.rm = FALSE) {
 
+  # remove NAs from data set
+  if (na.rm & any(is.na(x@other$ind.metrics$sex))) {
+    x <- x[!is.na(x@other$ind.metrics$sex)]
+  }
+  
   if (v > 0) {
     cat("Starting gl.sexlinkage: Identifying sex linked loci\n")
   }


### PR DESCRIPTION
We had some errors in the gl.sexlinkage function due to zeros in the sumf and summ values (used as denominators in the tests of proportion hetero/homozygotes. I've added a crude fix for this, which pulls out any zero-allele loci in a separate output (df_zero_sum) and includes a print statement for these.

I also added a check for missing sex IDs in the ind.metrics data.frame, which can be toggled with the na.rm argument.

I'd be happy to alter these changes if there is a way to categorise the zero-allele loci into zw or xy.