### PR TITLE
Add gh link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -108,5 +108,5 @@ Author: Bernd Gruber [aut, cre],
   Floriaan Devloo-Delva [ctb],
   Eric Archer [ctb]
 Config/testthat/edition: 3
-URL: https://green-striped-gecko.github.io/dartR/
+URL: https://green-striped-gecko.github.io/dartR/, https://github.com/green-striped-gecko/dartR
 BugReports: https://groups.google.com/g/dartr?pli=1


### PR DESCRIPTION
You may consider updating the website as v2.7.1 is appearing.

Consider running `usethis::use_pkgdown_github_pages()` locally to automate the publication of the site at each push.